### PR TITLE
Bugfix - Attempt Number Accuracy

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -69,6 +69,8 @@ func Example_httpGetWithStrategies() {
 
 func Example_withBackoffJitter() {
 	action := func(attempt uint) error {
+		fmt.Println("attempt", attempt)
+
 		return errors.New("something happened")
 	}
 
@@ -83,4 +85,11 @@ func Example_withBackoffJitter() {
 			jitter.Deviation(random, 0.5),
 		),
 	)
+
+	// Output:
+	// attempt 1
+	// attempt 2
+	// attempt 3
+	// attempt 4
+	// attempt 5
 }

--- a/retry.go
+++ b/retry.go
@@ -17,7 +17,7 @@ func Retry(action Action, strategies ...strategy.Strategy) error {
 	var err error
 
 	for attempt := uint(0); (attempt == 0 || err != nil) && shouldAttempt(attempt, strategies...); attempt++ {
-		err = action(attempt)
+		err = action(attempt + 1)
 	}
 
 	return err

--- a/retry_test.go
+++ b/retry_test.go
@@ -17,6 +17,43 @@ func TestRetry(t *testing.T) {
 	}
 }
 
+func TestRetryAttemptNumberIsAccurate(t *testing.T) {
+	var strategyAttemptNumber uint
+	var actionAttemptNumber uint
+
+	strategy := func(attempt uint) bool {
+		strategyAttemptNumber = attempt
+
+		return true
+	}
+
+	action := func(attempt uint) error {
+		actionAttemptNumber = attempt
+
+		return nil
+	}
+
+	err := Retry(action, strategy)
+
+	if err != nil {
+		t.Error("expected a nil error")
+	}
+
+	if strategyAttemptNumber != 0 {
+		t.Errorf(
+			"expected strategy to receive 0, received %v instead",
+			strategyAttemptNumber,
+		)
+	}
+
+	if actionAttemptNumber != 1 {
+		t.Errorf(
+			"expected action to receive 1, received %v instead",
+			actionAttemptNumber,
+		)
+	}
+}
+
 func TestRetryRetriesUntilNoErrorReturned(t *testing.T) {
 	const errorUntilAttemptNumber = 5
 

--- a/strategy/strategy.go
+++ b/strategy/strategy.go
@@ -15,9 +15,9 @@ import (
 // allows for the next attempt to be made. Returning `false` halts the retrying
 // process and returns the last error returned by the called Action.
 //
-// The strategy will be passed an "attempt" number on each successive retry
+// The strategy will be passed an "attempt" number before each successive retry
 // iteration, starting with a `0` value before the first attempt is actually
-// made. This allows for a pre-action delay, etc.
+// made. This allows for a pre-action, such as a delay, etc.
 type Strategy func(attempt uint) bool
 
 // Limit creates a Strategy that limits the number of attempts that Retry will

--- a/strategy/strategy.go
+++ b/strategy/strategy.go
@@ -24,7 +24,7 @@ type Strategy func(attempt uint) bool
 // make.
 func Limit(attemptLimit uint) Strategy {
 	return func(attempt uint) bool {
-		return (attempt <= attemptLimit)
+		return (attempt < attemptLimit)
 	}
 }
 

--- a/strategy/strategy_test.go
+++ b/strategy/strategy_test.go
@@ -10,9 +10,15 @@ import (
 const timeMarginOfError = time.Millisecond
 
 func TestLimit(t *testing.T) {
+	// Strategy attempts are 0-based.
+	// Treat this functionally as n+1.
 	const attemptLimit = 3
 
 	strategy := Limit(attemptLimit)
+
+	if !strategy(0) {
+		t.Error("strategy expected to return true")
+	}
 
 	if !strategy(1) {
 		t.Error("strategy expected to return true")
@@ -22,11 +28,7 @@ func TestLimit(t *testing.T) {
 		t.Error("strategy expected to return true")
 	}
 
-	if !strategy(3) {
-		t.Error("strategy expected to return true")
-	}
-
-	if strategy(4) {
+	if strategy(3) {
 		t.Error("strategy expected to return false")
 	}
 }


### PR DESCRIPTION
# What Happened?

Ooof... this is gross.

There's a couple of issues here that have existed for 5+ years:

 1. The `retry.Action` functions are sent an attempt number, but its been erroneously 0-based. The `strategy.Strategy` also receives an attempt number, but that's _supposed_ to be 0-based, as its supposed to allow for pre-run-logic. Sooo, yea, the attempt number sent to `retry.Action` has been off-by-one for all these years. 😞
 2. The `strategy.Limit` function has also had an off-by-one error for all these years... as the strategies are again supposed to be 0-based. Worse even, is that it used to be correct, and then somewhere along the line I thought I "fixed" it with commit 678601cc58fa358336a46de5c4c6305ab7875ca6. Damn. 😢


# The Fix

In any case, this PR fixes these errors!

The `retry.Action` attempt number will now always start at `1` and represent the actual attempt number of times that the action has been called, while `strategy.Strategy` functions will continue to receive the pre-action attempt number starting at `0` as usual. The `strategy.Limit` function has been fixed and tests have been expanded/improved to prevent this from happening again in the future. 🤞


# Impact

Yea, so this will definitely break backwards-compatibility. Existing `retry.Action` implementations will have to adapt to the new attempt number being `+1` compared to before, and existing code that uses `strategy.Limit` will have to expect that it'll there will be one fewer attempt than before (it was wrong before and giving one too many).

I'll be tagging a release once this is merged.