### PR TITLE
Chore - Upgrade CI for Go 1.17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.15.x', '1.16.x']
+        go: ['1.16.x', '1.17.x']
 
     steps:
     - name: Setup Go
@@ -48,7 +48,7 @@ jobs:
       run: make test-with-coverage-profile
 
     - name: Send code coverage to coveralls
-      if: ${{ matrix.go == '1.16.x' }}
+      if: ${{ matrix.go == '1.17.x' }}
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,6 @@
+//go:build tools
+// +build tools
+
 // Package tools provides tools for development.
 //
 // It follows the pattern set-forth in the wiki:
@@ -5,8 +8,6 @@
 //  - https://github.com/go-modules-by-example/index/tree/4ea90b07f9/010_tools
 //
 // Copyright © 2021 Trevor N. Suarez (Rican7)
-//
-// +build tools
 package tools
 
 import (


### PR DESCRIPTION
[Go 1.17 has been released.](https://go.dev/blog/go1.17).

Go 1.15.x is now dead. Go 1.16.x and 1.17.x are it.

See https://golang.org/doc/devel/release#policy