### PR TITLE
Fix exponential backoff algorithm truncating exponential factor

### DIFF
--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -34,7 +34,7 @@ func Linear(factor time.Duration) Algorithm {
 // calculated as the given base raised to the attempt number.
 func Exponential(factor time.Duration, base float64) Algorithm {
 	return func(attempt uint) time.Duration {
-		return (factor * time.Duration(math.Pow(base, float64(attempt))))
+		return time.Duration(float64(factor) * math.Pow(base, float64(attempt)))
 	}
 }
 

--- a/backoff/backoff_test.go
+++ b/backoff/backoff_test.go
@@ -40,13 +40,13 @@ func TestLinear(t *testing.T) {
 
 func TestExponential(t *testing.T) {
 	const duration = time.Second
-	const base = 3
+	const base = 1.5
 
 	algorithm := Exponential(duration, base)
 
 	for i := uint(0); i < 10; i++ {
 		result := algorithm(i)
-		expected := time.Duration(math.Pow(base, float64(i))) * duration
+		expected := time.Duration(math.Pow(base, float64(i)) * float64(duration))
 
 		if result != expected {
 			t.Errorf("algorithm expected to return a %s duration, but received %s instead", expected, result)
@@ -132,7 +132,7 @@ func ExampleLinear() {
 }
 
 func ExampleExponential() {
-	algorithm := Exponential(15*time.Millisecond, 3)
+	algorithm := Exponential(15*time.Millisecond, 1.5)
 
 	for i := uint(1); i <= 5; i++ {
 		duration := algorithm(i)
@@ -141,11 +141,11 @@ func ExampleExponential() {
 	}
 
 	// Output:
-	// #1 attempt: 45ms
-	// #2 attempt: 135ms
-	// #3 attempt: 405ms
-	// #4 attempt: 1.215s
-	// #5 attempt: 3.645s
+	// #1 attempt: 22.5ms
+	// #2 attempt: 33.75ms
+	// #3 attempt: 50.625ms
+	// #4 attempt: 75.9375ms
+	// #5 attempt: 113.90625ms
 }
 
 func ExampleBinaryExponential() {


### PR DESCRIPTION
The exponential backoff algorithm truncates the exponential factor when `math.Pow(base, float64(attempt))` is converted to `time.Duration` (the type conversion is from `float64` to `int64`).

This makes the delay between retries not increase exponentially when the base is a non-integer.
For example, the expected vs. actual results for the first five attempts of `Exponential(100 * time.Millisecond, 1.2)` are shown below:
attempt | expected | actual
---|---|---
1 | 120ms | 100ms
2 |144ms | 100ms
3 |172.8ms | 100ms
4 | 207.36ms | 200ms
5 | 248.832ms | 200ms

To fix this, multiply the duration factor by the exponential factor before converting anything back to `time.Duration`.